### PR TITLE
Added call to shut off the coffee switch

### DIFF
--- a/SmartCoffee SmartApp
+++ b/SmartCoffee SmartApp
@@ -106,6 +106,8 @@ def onHandler(evt) {
     		log.debug "The tank is now empty. Notifying that the coffee is done."
             	//Turning off the virtual switch
             theSwitch.off()
+	    //Added call to shut off the power source to the coffee pot as well. In case the coffee pot doesn't have auto off
+	    coffee.off()
             	// Delay push notification
             log.debug "Pushing notification in ${secondsAfterClosed} seconds."
             sendPush()


### PR DESCRIPTION
Some coffee pots don't have an auto off function (like mine) so added an extra command to kill power to the coffee pot power source when the tank switches from wet to dry. This will cover coffee ports with and without an auto off